### PR TITLE
Bug 919901 - B2G Emulator: A signal dispatching bug in Linux 2.6.29

### DIFF
--- a/arch/arm/include/asm/ptrace.h
+++ b/arch/arm/include/asm/ptrace.h
@@ -65,6 +65,13 @@
 #define PSR_x		0x0000ff00	/* Extension		*/
 #define PSR_c		0x000000ff	/* Control		*/
 
+/*
+ * ARMv7 groups of APSR bits
+ */
+#define PSR_ISET_MASK	0x01000010	/* ISA state (J, T) mask */
+#define PSR_IT_MASK	0x0600fc00	/* If-Then execution state mask */
+#define PSR_ENDIAN_MASK	0x00000200	/* Endianness state mask */
+
 #ifndef __ASSEMBLY__
 
 /*

--- a/arch/arm/kernel/signal.c
+++ b/arch/arm/kernel/signal.c
@@ -426,9 +426,13 @@ setup_return(struct pt_regs *regs, struct k_sigaction *ka,
 		 */
 		thumb = handler & 1;
 
-		if (thumb)
+		if (thumb) {
 			cpsr |= PSR_T_BIT;
-		else
+#if __LINUX_ARM_ARCH__ >= 7
+			/* clear the If-Then Thumb-2 execution state */
+			cpsr &= ~PSR_IT_MASK;
+#endif
+		} else
 			cpsr &= ~PSR_T_BIT;
 	}
 #endif


### PR DESCRIPTION
Clear the IT state when invoking a Thumb-2 signal handler

If a process is interrupted during an If-Then block and a signal is
invoked, the ITSTATE bits must be cleared otherwise the handler would
not run correctly.

Signed-off-by: Catalin Marinas catalin.marinas@arm.com
Cc: Joseph S. Myers joseph@codesourcery.com
